### PR TITLE
Add new !GetCidr function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the "aws-cloudformation-yaml" extension will be documente
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.1.3] - 2018.03.09
+
+### Added
+
+* Intrinsic function snippets
+  * !GetCidr
+
 ## [0.1.2] - 2017.10.19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Following Snippets do provide this extension for YAML files:
     * __!FindInMap__
     * __!GetAtt__
     * __!GetAZs__
+    * __!GetCidr__    
     * __!ImportValue__
     * __!Join__
     * __!Select__

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Following snippets do provide this extenstion for JSON files:
 ## Release Notes
 
 You will find all release notes under following link:
-[Release Notes](https://github.com/dthielking/aws-cloudformation-yaml/blob/master/CHANGELOG.md)
+[Release Notes](CHANGELOG.md)

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -163,6 +163,11 @@
         "body": "!GetAZs ${0:Region}",
         "description": "Add !GetAZs function"
     },
+    "GetCidr": {
+        "prefix": "!GetCidr",
+        "body": "!GetCidr [${1:IpBlock}, ${2:Count}, ${3:SizeMask}]",
+        "description": "Add !GetCidr function"
+    },
     "ImportValue": {
         "prefix": "!ImportValue",
         "body": "!ImportValue ${1:ValueToImport}",


### PR DESCRIPTION
Adds function !GetCidr launched in Mar 6, 2018.
[Release History](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/ReleaseHistory.html)