### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the "aws-cloudformation-yaml" extension will be documente
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [0.2.1] - 2018.03.29
+
+### Added
+
+* Added jump marker to output section of AWSTemplate Snippet
+
+### Changed
+
+* Fixed Bug with !Sub command
+  * After typing Sub completion result was !Sub: colon is wrong
+* Changed description of AWSTemplate snippet
+
+## [0.2.0]
+
+* ???
+
 ## [0.1.2] - 2017.10.19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "aws-cloudformation-yaml",
     "displayName": "aws-cloudformation-yaml",
     "description": "Adds YAML and JSON snippets for AWS CloudFormation to VS Code",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "publisher": "DanielThielking",
     "engines": {
         "vscode": "^1.14.0"

--- a/snippets/yaml.json
+++ b/snippets/yaml.json
@@ -50,16 +50,14 @@
             "      - BranchName",
             "",
             "Mappings:",
-            "  CFNBucket:",
-            "    AllRegions:",
-            "      BucketUrl: https://clouds-configuration.s3.amazonaws.com/clouds/cfn",
             "",
             "Resources:",
             "  $0",
             "",
-            "Outputs:"
+            "Outputs:",
+            "  $1"
         ],
-        "description": "This snippet provides a complete AWS template structure."
+        "description": "This snippet provides a complete AWS CFN template structure."
     },
     "Parameter": {
         "prefix": "Parameter",
@@ -191,7 +189,7 @@
     "Sub": {
         "prefix": "!Sub",
         "body": [
-            "!Sub:",
+            "!Sub",
             "- ${1:StringWithVariables}",
             "- { ${2:VarName}: ${3:VarValue}$0 }"
         ],


### PR DESCRIPTION
* Added jump marker to output section of AWSTemplate Snippet
* Fixed Bug with !Sub command
  * After typing Sub completion result was !Sub: colon is wrong
* Changed description of AWSTemplate snippet